### PR TITLE
Fix extra fields not being created

### DIFF
--- a/src/nt/nttable.cpp
+++ b/src/nt/nttable.cpp
@@ -58,12 +58,11 @@ StructureConstPtr NTTableBuilder::createStructure()
     if (timeStamp)
         builder->add("timeStamp", ntField->createTimeStamp());
 
-    StructureConstPtr s = builder->createStructure();
-
     size_t extraCount = extraFieldNames.size();
     for (size_t i = 0; i< extraCount; i++)
         builder->add(extraFieldNames[i], extraFields[i]);
 
+    StructureConstPtr s = builder->createStructure();
 
     reset();
     return s;


### PR DESCRIPTION
FieldBuilder::createStructure() was being called too early inside NTTableBuilder::createStructure(), preventing extra fields from being properly created.