### PR TITLE
Cleanup whitespace

### DIFF
--- a/src/ntfield.cpp
+++ b/src/ntfield.cpp
@@ -239,4 +239,3 @@ PVStructureArrayPtr PVNTField::createAlarmArray()
 }
 
 }}
-

--- a/src/ntid.cpp
+++ b/src/ntid.cpp
@@ -186,5 +186,3 @@ namespace nt {
 
 
 }}
-
-

--- a/src/ntid.cpp
+++ b/src/ntid.cpp
@@ -7,11 +7,11 @@
 #include <pv/ntid.h>
 #include <pv/typeCast.h>
 
-namespace epics { 
+namespace epics {
 
 namespace nt {
 
-    const static std::string BAD_NAME = "?"; 
+    const static std::string BAD_NAME = "?";
 
     NTID::NTID(const std::string & id)
     : fullName(id),
@@ -81,7 +81,7 @@ namespace nt {
             else
             {
                 name = fullName;
-            } 
+            }
         }
         return name;
     }
@@ -105,7 +105,7 @@ namespace nt {
             {
                 endMajorIndex = fullName.find('.', versionSepIndex+1);
                 majorVersionStr = (endMajorIndex != std::string::npos)
-                    ? fullName.substr(versionSepIndex+1, endMajorIndex-(versionSepIndex+1)) : 
+                    ? fullName.substr(versionSepIndex+1, endMajorIndex-(versionSepIndex+1)) :
                       fullName.substr(versionSepIndex+1);
             }
             else
@@ -150,7 +150,7 @@ namespace nt {
             {
                 endMinorIndex = fullName.find('.', endMajorIndex+1);
                 minorVersionStr = (endMinorIndex != std::string::npos)
-                    ? fullName.substr(endMajorIndex+1, endMinorIndex-(endMajorIndex+1)) : 
+                    ? fullName.substr(endMajorIndex+1, endMinorIndex-(endMajorIndex+1)) :
                       fullName.substr(endMajorIndex+1);
             }
             else

--- a/src/ntmultiChannel.cpp
+++ b/src/ntmultiChannel.cpp
@@ -15,7 +15,7 @@
 using namespace std;
 using namespace epics::pvData;
 
-namespace epics { namespace nt { 
+namespace epics { namespace nt {
 
 
 static FieldCreatePtr fieldCreate = getFieldCreate();
@@ -269,7 +269,7 @@ bool NTMultiChannel::isValid()
     if (getChannelName()->getLength() != valueLength) return false;
 
     PVScalarArrayPtr arrayFields[] = {
-          getSeverity(), getStatus(), getMessage(), 
+          getSeverity(), getStatus(), getMessage(),
           getSecondsPastEpoch(), getNanoseconds(), getUserTag()
     };
     size_t N = sizeof(arrayFields)/sizeof(arrayFields[0]);
@@ -281,7 +281,7 @@ bool NTMultiChannel::isValid()
         if (arrayField.get() && arrayField->getLength() != valueLength)
             return false;
     }
-    return true; 
+    return true;
 }
 
 

--- a/src/ntnameValue.cpp
+++ b/src/ntnameValue.cpp
@@ -140,7 +140,7 @@ bool NTNameValue::isCompatible(StructureConstPtr const & structure)
         return false;
 
     Result result(structure);
-    
+
     return result
         .is<Structure>()
         .has<ScalarArray>("name")

--- a/src/ntndarray.cpp
+++ b/src/ntndarray.cpp
@@ -71,7 +71,7 @@ StructureConstPtr NTNDArrayBuilder::createStructure()
                 ScalarType st = static_cast<ScalarType>(i);
                 fb->addArray(std::string(ScalarTypeFunc::name(st)) + "Value", st);
             }
-            valueType = fb->createUnion();                
+            valueType = fb->createUnion();
         }
 
         if (!codecStruc)
@@ -127,7 +127,7 @@ StructureConstPtr NTNDArrayBuilder::createStructure()
         returnedStruc = fb->createStructure();
 
         if (!isExtended)
-            ntndarrayStruc[index] = returnedStruc; 
+            ntndarrayStruc[index] = returnedStruc;
     }
     else
     {

--- a/src/ntscalarMultiChannel.cpp
+++ b/src/ntscalarMultiChannel.cpp
@@ -13,7 +13,7 @@
 using namespace std;
 using namespace epics::pvData;
 
-namespace epics { namespace nt { 
+namespace epics { namespace nt {
 
 
 static FieldCreatePtr fieldCreate = getFieldCreate();
@@ -263,7 +263,7 @@ bool NTScalarMultiChannel::isValid()
     if (getChannelName()->getLength() != valueLength) return false;
 
     PVScalarArrayPtr arrayFields[] = {
-          getSeverity(), getStatus(), getMessage(), 
+          getSeverity(), getStatus(), getMessage(),
           getSecondsPastEpoch(), getNanoseconds(), getUserTag()
     };
     size_t N = sizeof(arrayFields)/sizeof(arrayFields[0]);
@@ -275,7 +275,7 @@ bool NTScalarMultiChannel::isValid()
         if (arrayField.get() && arrayField->getLength() != valueLength)
             return false;
     }
-    return true; 
+    return true;
 }
 
 NTScalarMultiChannelBuilderPtr NTScalarMultiChannel::createBuilder()

--- a/src/nttable.cpp
+++ b/src/nttable.cpp
@@ -188,7 +188,7 @@ bool NTTable::isCompatible(PVStructurePtr const & pvStructure)
 bool NTTable::isValid()
 {
     PVFieldPtrArray const & columns = pvValue->getPVFields();
-        
+
     if (getLabels()->getLength() != columns.size()) return false;
     bool first = true;
     int length = 0;

--- a/test/ntaggregateTest.cpp
+++ b/test/ntaggregateTest.cpp
@@ -78,7 +78,7 @@ void test_ntaggregate()
     // example how to set a value
     //
     ntAggregate->getValue()->put(1.0);
-    
+
     //
     // example how to get a value
     //

--- a/test/ntaggregateTest.cpp
+++ b/test/ntaggregateTest.cpp
@@ -173,5 +173,3 @@ MAIN(testNTAggregate) {
     test_wrap();
     return testDone();
 }
-
-

--- a/test/ntattributeTest.cpp
+++ b/test/ntattributeTest.cpp
@@ -173,5 +173,3 @@ MAIN(testNTAttribute) {
     test_wrap();
     return testDone();
 }
-
-

--- a/test/ntcontinuumTest.cpp
+++ b/test/ntcontinuumTest.cpp
@@ -274,5 +274,3 @@ MAIN(testNTContinuum) {
     test_extra();
     return testDone();
 }
-
-

--- a/test/ntenumTest.cpp
+++ b/test/ntenumTest.cpp
@@ -84,7 +84,7 @@ void test_ntenum()
     choices[1] = "On";
     pvValue->getSubField<PVStringArray>("choices")->replace(freeze(choices));
     pvValue->getSubField<PVInt>("index")->put(1);
-    
+
     //
     // example how to get a value
     //

--- a/test/ntenumTest.cpp
+++ b/test/ntenumTest.cpp
@@ -185,5 +185,3 @@ MAIN(testNTEnum) {
     test_wrap();
     return testDone();
 }
-
-

--- a/test/nthistogramTest.cpp
+++ b/test/nthistogramTest.cpp
@@ -259,5 +259,3 @@ MAIN(testNTHistogram) {
     test_extra();
     return testDone();
 }
-
-

--- a/test/ntmatrixTest.cpp
+++ b/test/ntmatrixTest.cpp
@@ -207,5 +207,3 @@ MAIN(testNTMatrix) {
     test_wrap();
     return testDone();
 }
-
-

--- a/test/ntmultiChannelTest.cpp
+++ b/test/ntmultiChannelTest.cpp
@@ -193,4 +193,3 @@ MAIN(testCreateRequest)
     test_wrap();
     return testDone();
 }
-

--- a/test/ntnameValueTest.cpp
+++ b/test/ntnameValueTest.cpp
@@ -254,5 +254,3 @@ MAIN(testNTNameValue) {
     test_extra();
     return testDone();
 }
-
-

--- a/test/ntndarrayAttributeTest.cpp
+++ b/test/ntndarrayAttributeTest.cpp
@@ -175,5 +175,3 @@ MAIN(testNTNDArrayAttribute) {
     test_wrap();
     return testDone();
 }
-
-

--- a/test/ntndarrayTest.cpp
+++ b/test/ntndarrayTest.cpp
@@ -120,5 +120,3 @@ MAIN(testNTNDArray) {
     test_wrap();
     return testDone();
 }
-
-

--- a/test/ntndarrayTest.cpp
+++ b/test/ntndarrayTest.cpp
@@ -21,8 +21,8 @@ void test_builder(bool extraFields)
     testOk(builder.get() != 0, "Got builder");
 
     builder->addDescriptor()->
-             addTimeStamp()->          
-             addAlarm()->  
+             addTimeStamp()->
+             addAlarm()->
              addDisplay();
 
     if (extraFields)
@@ -68,9 +68,9 @@ void test_all()
 
     PVStructurePtr pvStructure = builder->
             addDescriptor()->
-            addTimeStamp()->          
-            addAlarm()->  
-            addDisplay()->  
+            addTimeStamp()->
+            addAlarm()->
+            addDisplay()->
             add("extra1",fieldCreate->createScalar(pvString)) ->
             add("extra2",fieldCreate->createScalarArray(pvString)) ->
             createPVStructure();

--- a/test/ntscalarArrayTest.cpp
+++ b/test/ntscalarArrayTest.cpp
@@ -242,5 +242,3 @@ MAIN(testNTScalarArray) {
     test_wrap();
     return testDone();
 }
-
-

--- a/test/ntscalarMultiChannelTest.cpp
+++ b/test/ntscalarMultiChannelTest.cpp
@@ -180,4 +180,3 @@ MAIN(testCreateRequest)
     test_wrap();
     return testDone();
 }
-

--- a/test/ntscalarTest.cpp
+++ b/test/ntscalarTest.cpp
@@ -233,5 +233,3 @@ MAIN(testNTScalar) {
     test_wrap();
     return testDone();
 }
-
-

--- a/test/nttableTest.cpp
+++ b/test/nttableTest.cpp
@@ -245,5 +245,3 @@ MAIN(testNTTable) {
     test_wrap();
     return testDone();
 }
-
-

--- a/test/ntunionTest.cpp
+++ b/test/ntunionTest.cpp
@@ -196,5 +196,3 @@ MAIN(testNTUnion) {
     test_regular_union();
     return testDone();
 }
-
-

--- a/test/ntutilsTest.cpp
+++ b/test/ntutilsTest.cpp
@@ -33,5 +33,3 @@ MAIN(testNTUtils) {
     test_is_a();
     return testDone();
 }
-
-

--- a/test/validatorTest.cpp
+++ b/test/validatorTest.cpp
@@ -90,7 +90,7 @@ void test_is_id()
         testOk(!result.valid(), "!Result(Union['TEST_ID']).is<Structure>('TEST_ID').valid()");
         testOk1(result.errors.at(0) == Result::Error("", Result::Error::IncorrectType));
     }
-    
+
     {
         // Type matches, ID doesn't
         Result result(FB->setId("WRONG_ID")->createStructure());
@@ -140,7 +140,7 @@ void test_has()
         result
            .has<Scalar>("A")
            .has<ScalarArray>("B");
-        testOk(!result.valid(), 
+        testOk(!result.valid(),
             "!Result(%s).has<Scalar>('A').has<ScalarArray>('B').valid()",
             strucRepr.c_str());
         testOk1(result.errors.at(0) == Result::Error("B", Result::Error::IncorrectType));
@@ -152,7 +152,7 @@ void test_has()
         result
            .has<Scalar>("A")
            .has<Scalar>("C");
-        testOk(!result.valid(), 
+        testOk(!result.valid(),
             "!Result(%s).has<Scalar>('A').has<Scalar>('C').valid()",
             strucRepr.c_str());
         testOk1(result.errors.at(0) == Result::Error("C", Result::Error::MissingField));
@@ -199,7 +199,7 @@ void test_maybe_has()
         result
            .maybeHas<Scalar>("A")
            .maybeHas<ScalarArray>("B");
-        testOk(!result.valid(), 
+        testOk(!result.valid(),
             "!Result(%s).maybeHas<Scalar>('A').maybeHas<ScalarArray>('B').valid()",
             strucRepr.c_str());
         testOk1(result.errors.at(0) == Result::Error("B", Result::Error::IncorrectType));
@@ -211,7 +211,7 @@ void test_maybe_has()
         result
            .maybeHas<Scalar>("A")
            .maybeHas<Scalar>("C");
-        testOk(result.valid(), 
+        testOk(result.valid(),
             "Result(%s).maybeHas<Scalar>('A').maybeHas<Scalar>('C').valid()",
             strucRepr.c_str());
     }


### PR DESCRIPTION
This is purely cosmetic:
1. There was a mess with tab character usage. Indention with spaces and tabs was mixed inconsistently sometimes with obviously different assumptions on tab width, even in the same file. This results in irregular, hard to read indents. Please stop using tabs in source code.
2. Clean up of space at end of line.
3. Clean up of empty lines at end of file.