### PR TITLE
Fix possible NULL deref in NTNDArray::getValueSize()

### DIFF
--- a/src/ntndarray.cpp
+++ b/src/ntndarray.cpp
@@ -327,10 +327,8 @@ int64 NTNDArray::getValueSize()
 {
     int64 size = 0;
     PVScalarArrayPtr storedValue = getValue()->get<PVScalarArray>();
-    if (!storedValue.get())
-    {
+    if (storedValue.get())
         size = storedValue->getLength()*getValueTypeSize();
-    }
     return size;
 }
 


### PR DESCRIPTION
This showed up as a warning when compiling. The incorrect NULL check in `NTNDArray::getValueSize()` would result in `NTNDArray::getValueSize()` always returning 0, or crashing if there is no stored value.

As a result, it looks like `NTNDArray::isValid()` would almost always return false, unless `compressedSize` is also 0:
```cpp
bool NTNDArray::isValid()
{
    int64 valueSize = getValueSize();
    int64 compressedSize = getCompressedDataSize()->get();
    if (valueSize != compressedSize)
        return false;
    ...
}
```